### PR TITLE
main: prefer current directory by default over hard-coded paths

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@ main (void) {
     struct lwan l;
     struct lwan_config c = *lwan_get_default_config();
 
-    db = pandabin_db_init(PREFIX "/" PROGNM "/db.sqlite");
+    db = pandabin_db_init(PROGNM "/db.sqlite");
     if ( !db ) { status = EXIT_FAILURE; goto cleanup; }
 
     pandabin_settings_fetch(db);
@@ -102,4 +102,3 @@ pandabin_dir_init (void) {
             syslog(LOG_ERR, "Failed to cd to %s: %s\n", cwd, strerror(status));
         } return status;
 }
-

--- a/src/main.h
+++ b/src/main.h
@@ -38,10 +38,9 @@ extern sqlite3_stmt * sql_hndls [LAST];
 extern struct pandabin_settings settings;
 
 // Configurables
-#define PREFIX   "/home/halosghost"
 #define MAXSIZE  67108864
 #define PROGNM   "pandabin"
-#define FILEPATH PREFIX "/" PROGNM "/files"
+#define FILEPATH PROGNM "/files"
 
 #define FAIL(...) do { \
     status = errno; \

--- a/src/sql.h
+++ b/src/sql.h
@@ -55,6 +55,6 @@ static const char * pandabin_schema =
     "insert or ignore into 'settings' values"
     "  ('max size', 67108864),"
     "  ('instance name', 'localhost'),"
-    "  ('file path', '/usr/local');";
+    "  ('file path', '.');";
 
 #endif


### PR DESCRIPTION
Minimal fix for #22.

It also seems inconsistent to store content and metadata in separate directories--they are the same kind of data.
