### PR TITLE
sql: explictly request threadsafe sqlite start-time configuration

### DIFF
--- a/src/sql.c
+++ b/src/sql.c
@@ -6,6 +6,12 @@ pandabin_db_init (const char * path) {
     signed status = EXIT_SUCCESS;
     sqlite3 * db = 0;
 
+    status = sqlite3_config(SQLITE_CONFIG_SERIALIZED);
+    if ( status != SQLITE_OK ) {
+        errno = status;
+        FAIL("incompatible non-threadsafe sqlite");
+    }
+
     status = sqlite3_open(path, &db);
     if ( status != SQLITE_OK ) {
         errno = status;
@@ -278,4 +284,3 @@ pandabin_paste_path (const char * hash) {
             if ( path ) { free(path); path = NULL; }
         } return path;
 }
-


### PR DESCRIPTION
This does two things:

 - prevents pandabin from being run with a compile-time singlethread sqlite lacking mutex support
 - specifically requests serialized mode, which is [required](https://sqlite.org/threadsafe.html) due to a single db object being shared between multiple threads/requests
